### PR TITLE
Fix importing of feeds where null instance references can contain spaces

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,3 +1,4 @@
 Authors
 =======
 * John Whitlock (John-Whitlock@ieee.org)
+* Juha Yrjölä (juha.yrjola@iki.fi)

--- a/multigtfs/models/base.py
+++ b/multigtfs/models/base.py
@@ -1,6 +1,6 @@
-#
+# -*- coding: utf-8 -*-
 # Copyright 2012-2014 John Whitlock
-#
+# Copyright 2014 Juha Yrjölä
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
The Helsinki Region Transport GTFS feed sometimes refers to parentless stops with a space (" ") in the `parent_station` field. Work around that problem by stripping the value before checking for the empty condition.
