### PR TITLE
strip values from feeds so whitespace isn't stored and whitespace str…

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Authors
 * Juha Yrjölä (`juyrjola <https://github.com/juyrjola>`_, juha.yrjola@iki.fi)
 * Kevin Diale (`powersurge360 <https://github.com/powersurge360>`_, powersurge360@gmail.com)
 * Adam Lawrence (`alaw005 <https://github.com/alaw005>`_, alaw005@gmail.com)
+* Dave Kroondyk (`davekaro <https://github.com/davekaro>`_, davekaro@gmail.com)

--- a/multigtfs/models/base.py
+++ b/multigtfs/models/base.py
@@ -117,9 +117,9 @@ class Base(models.Model):
 
         def bool_convert(value): return (value == '1')
 
-        def char_convert(value): return (value or '')
+        def char_convert(value): return (value.strip() or '')
 
-        def null_convert(value): return (value or None)
+        def null_convert(value): return (value.strip() or None)
 
         def point_convert(value): return (value or 0.0)
 


### PR DESCRIPTION
…ings are treated as null

the sfmta transit data has rows like , , , that are parsed
to strings like ' ' during import