### PR TITLE
Management command compatibility with django >= 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,25 @@ matrix:
           python: "3.4"
         - env: TOX_ENV=py35-django110-postgis
           python: "3.5"
+        - env: TOX_ENV=py27-django111-postgis
+          python: "2.7"
+        - env: TOX_ENV=py34-django111-postgis
+          python: "3.4"
+        - env: TOX_ENV=py35-django111-postgis
+          python: "3.5"
+        - env: TOX_ENV=py36-django111-postgis
+          python: "3.6"
         - env: TOX_ENV=py27-djangomaster-postgis
           python: "2.7"
         - env: TOX_ENV=py34-djangomaster-postgis
           python: "3.4"
         - env: TOX_ENV=py35-djangomaster-postgis
           python: "3.5"
+        - env: TOX_ENV=py36-djangomaster-postgis
+          python: "3.6"
     allow_failures:
         # Django master is allowed to fail
         - env: TOXENV=py27-djangomaster-postgis
         - env: TOXENV=py34-djangomaster-postgis
         - env: TOXENV=py35-djangomaster-postgis
+        - env: TOXENV=py36-djangomaster-postgis

--- a/multigtfs/management/commands/exportgtfs.py
+++ b/multigtfs/management/commands/exportgtfs.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import unicode_literals
-from optparse import make_option
 import logging
 
 from django.db import connection
@@ -25,19 +24,21 @@ from multigtfs.models.feed import Feed
 
 
 class Command(BaseCommand):
-    args = '<feed ID>'
-    help = 'Exports a GTFS Feed from a zipped feed file'
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '-n', '--name', type='string', dest='name',
-            help='Set the name of the exported feed'),)
+    help = 'Exports a GTFS Feed to a zipped feed file'
+
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument('feed_id',
+                            metavar='GTFS Feed ID',
+                            type=int)
+
+        # Named (optional) arguments
+        parser.add_argument('-n', '--name',
+                            type=str,
+                            dest='name',
+                            help='Set the name of the exported feed')
 
     def handle(self, *args, **options):
-        if len(args) == 0:
-            raise CommandError('You must pass in feed ID to export.')
-        if len(args) > 1:
-            raise CommandError('You can only export one feed at a time.')
-
         # Setup logging
         verbosity = int(options['verbosity'])
         console = logging.StreamHandler(self.stderr)
@@ -64,10 +65,8 @@ class Command(BaseCommand):
         if settings.DEBUG:
             connection.use_debug_cursor = False
 
-        try:
-            feed_id = int(args[0])
-        except ValueError:
-            raise CommandError('"%s" is not a valid feed ID' % args[0])
+        feed_id = options.get('feed_id')
+
         try:
             feed = Feed.objects.get(id=feed_id)
         except Feed.DoesNotExist:

--- a/multigtfs/management/commands/importgtfs.py
+++ b/multigtfs/management/commands/importgtfs.py
@@ -18,7 +18,7 @@ import logging
 
 from django.db import connection
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from multigtfs.models import Agency, Feed, Service
 

--- a/multigtfs/management/commands/importgtfs.py
+++ b/multigtfs/management/commands/importgtfs.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 from __future__ import unicode_literals
 from datetime import datetime
-from optparse import make_option
 import logging
 
 from django.db import connection
@@ -25,21 +24,25 @@ from multigtfs.models import Agency, Feed, Service
 
 
 class Command(BaseCommand):
-    args = '<gtfsfeed.zip or folder>'
     help = 'Import a GTFS Feed'
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '-n', '--name', type='string', dest='name',
-            help=(
-                'Set the name of the imported feed.  Defaults to name derived'
-                ' from agency name and start date')),)
+
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument('gtfs_feed',
+                            metavar='<gtfsfeed.zip or folder>',
+                            type=str)
+
+        # Named (optional) arguments
+        parser.add_argument('-n', '--name',
+                            type=str,
+                            dest='name',
+                            help=(
+                                'Set the name of the imported feed.  Defaults'
+                                ' to name derived from agency name and'
+                                ' start date'))
 
     def handle(self, *args, **options):
-        if len(args) == 0:
-            raise CommandError('You must pass in the path to the feed.')
-        if len(args) > 1:
-            raise CommandError('You can only import one feed at a time.')
-        gtfs_feed = args[0]
+        gtfs_feed = options.get('gtfs_feed')
         unset_name = 'Imported at %s' % datetime.now()
         name = options.get('name') or unset_name
 

--- a/multigtfs/tests/test_shape.py
+++ b/multigtfs/tests/test_shape.py
@@ -165,7 +165,7 @@ S1,36.425288,-117.133162,1,1.1
             shape.geometry.coords,
             ((-117.133162, 36.425288), (-117.13, 36.42)))
         self.assertEqual(trip.geometry, shape.geometry)
-        self.assertEqual(route.geometry, MultiLineString(shape.geometry))
+        self.assertEqual(route.geometry, MultiLineString(shape.geometry, srid=4326))
 
     def test_update_geometry_no_parent(self):
         shape = Shape.objects.create(feed=self.feed)

--- a/multigtfs/tests/test_stop.py
+++ b/multigtfs/tests/test_stop.py
@@ -291,4 +291,4 @@ FUR_CREEK_RES,Furnace Creek Resort (Demo),36.425288,-117.133162,7
         self.assertEqual(
             trip.geometry.coords,
             ((-117.133162, 36.425288), (-117.13, 36.42)))
-        self.assertEqual(route.geometry, MultiLineString(trip.geometry))
+        self.assertEqual(route.geometry, MultiLineString(trip.geometry, srid=4326))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{27,34}-django18-{postgis,spatiallite}
-    py{27,34,35}-django{19,110,master}-{postgis,spatiallite}
+    py{27,34,35}-django{19,110}-{postgis,spatiallite}
+    py{27,34,35,36}-django{111,master}-{postgis,spatiallite}
 
 [flake8]
 exclude = .tox/* .build/* .dist/*
@@ -14,6 +15,7 @@ deps=
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django==1.10,<1.11
+    django111: Django>=1.11,<2.0
     django-master: https://github.com/django/django/archive/master.tar.gz
     postgis: psycopg2
     nose


### PR DESCRIPTION
Rewrote options parsers for importgtfs, exportgtfs, and refreshgeometries. Using opt parse was deprecated in 1.8 and removed in 1.10.

Also modified two tests to ensure compatibility with changes made to the Geos module in Django 1.11