### PR TITLE
Use skipinitialspace in CSV reader

### DIFF
--- a/multigtfs/models/base.py
+++ b/multigtfs/models/base.py
@@ -117,9 +117,9 @@ class Base(models.Model):
 
         def bool_convert(value): return (value == '1')
 
-        def char_convert(value): return (value.strip() or '')
+        def char_convert(value): return (value or '')
 
-        def null_convert(value): return (value.strip() or None)
+        def null_convert(value): return (value or None)
 
         def point_convert(value): return (value or 0.0)
 
@@ -211,7 +211,7 @@ class Base(models.Model):
                 val_map[csv_name] = converter
 
         # Read and convert the source txt
-        csv_reader = reader(txt_file)
+        csv_reader = reader(txt_file, skipinitialspace=True)
         unique_line = dict()
         count = 0
         first = True

--- a/multigtfs/tests/test_shape.py
+++ b/multigtfs/tests/test_shape.py
@@ -165,7 +165,8 @@ S1,36.425288,-117.133162,1,1.1
             shape.geometry.coords,
             ((-117.133162, 36.425288), (-117.13, 36.42)))
         self.assertEqual(trip.geometry, shape.geometry)
-        self.assertEqual(route.geometry, MultiLineString(shape.geometry, srid=4326))
+        self.assertEqual(route.geometry,
+                         MultiLineString(shape.geometry, srid=4326))
 
     def test_update_geometry_no_parent(self):
         shape = Shape.objects.create(feed=self.feed)

--- a/multigtfs/tests/test_stop.py
+++ b/multigtfs/tests/test_stop.py
@@ -307,4 +307,5 @@ FUR_CREEK_RES,Furnace Creek Resort (Demo),36.425288,-117.133162,7
         self.assertEqual(
             trip.geometry.coords,
             ((-117.133162, 36.425288), (-117.13, 36.42)))
-        self.assertEqual(route.geometry, MultiLineString(trip.geometry, srid=4326))
+        self.assertEqual(route.geometry,
+                         MultiLineString(trip.geometry, srid=4326))

--- a/multigtfs/tests/test_trip.py
+++ b/multigtfs/tests/test_trip.py
@@ -116,6 +116,20 @@ R1,S2,T1
         self.assertEqual(trip.service, service1)
         self.assertFalse(service2.trip_set.exists())
 
+    def test_import_trips_txt_quoted_direction_id(self):
+        '''
+        A direction_id should be stripped of quotation marks
+
+        Issue 64
+        '''
+        trips_txt = StringIO("""\
+route_id,service_id,trip_id,shape_id,trip_headsign,direction_id
+R1,"S1","T3","46-860-y11-1.2.I","Aston Quay", "1"
+""")
+        Trip.import_txt(trips_txt, self.feed)
+        trip = Trip.objects.get(trip_id='T3')
+        self.assertEqual(trip.direction, '1')
+
     def test_export_trips_txt_empty(self):
         trips_txt = Trip.export_txt(self.feed)
         self.assertFalse(trips_txt)

--- a/qa_check.sh
+++ b/qa_check.sh
@@ -11,4 +11,4 @@ coverage erase
 coverage run --source multigtfs ${COVERAGE_OMIT} ./run_tests.py
 if [[ $? -ne 0 ]]; then exit 1; fi
 coverage report
-flake8 --exclude=".tox" .
+flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py{35,36}-django-master-{postgis,spatiallite}
 
 [flake8]
-exclude = .tox/* .build/* .dist/*
+exclude = .tox/*,.build/*,.dist/*,build/*
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
More feeds appear to be using whitespace in their CSV, (issues #56, #64), causing issues when processing the values. This adds the [skipinitialspace](https://docs.python.org/2/library/csv.html#csv.Dialect.skipinitialspace) option to the CSV reader, stripping them before we get to value processing.

I've also gotten ``qa_check.sh`` running cleanly again.