### PR TITLE
Fix issue #70: Latitude / Longitude with leading +

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Next (unreleased)
+~~~~~~~~~~~~~~~~~
+* Handle latitude and longitudes with initial `+` sign.
+  (`issue #70`_).
+
+.. _`issue #70`: https://github.com/tulsawebdevs/django-multi-gtfs/issues/70
+
 1.1.1 (2017-08-02)
 ------------------
 * Strip whitespace after commas in CSV files with skipinitialspace_

--- a/multigtfs/models/base.py
+++ b/multigtfs/models/base.py
@@ -121,7 +121,12 @@ class Base(models.Model):
 
         def null_convert(value): return (value or None)
 
-        def point_convert(value): return (value or 0.0)
+        def point_convert(value):
+            """Convert latitude / longitude, strip leading +."""
+            if value.startswith('+'):
+                return value[1:]
+            else:
+                return (value or 0.0)
 
         cache = {}
 

--- a/multigtfs/tests/test_stop.py
+++ b/multigtfs/tests/test_stop.py
@@ -83,6 +83,24 @@ FUR_CREEK_RES,Furnace Creek Resort (Demo),,36.425288,-117.133162
         self.assertEqual(stop.timezone, '')
         self.assertEqual(stop.wheelchair_boarding, '')
 
+    def test_import_stops_txt_plus_point(self):
+        """Test issue #70, latitude / longitude with leading plus sign."""
+        stops_txt = StringIO("""\
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,location_type,parent_station
+10258,TANEU,TANNEURS,,+49.119799,+06.182966,1,
+""")
+        Stop.import_txt(stops_txt, self.feed)
+        stop = Stop.objects.get()
+        self.assertEqual(stop.feed, self.feed)
+        self.assertEqual(stop.stop_id, '10258')
+        self.assertEqual(stop.code, 'TANEU')
+        self.assertEqual(stop.name, 'TANNEURS')
+        self.assertEqual(stop.desc, '')
+        self.assertEqual(str(stop.lat), '49.119799')
+        self.assertEqual(str(stop.lon), '6.182966')
+        self.assertEqual(stop.location_type, '1')
+        self.assertEqual(stop.parent_station, None)
+
     def test_import_stops_txt_extra_columns(self):
         stops_txt = StringIO("""\
 stop_id,stop_name,stop_desc,stop_lat,stop_lon,platform_code


### PR DESCRIPTION
Issue #70 is an error when the latitude or longitude starts with a plus sign (+), seen on https://si.metzmetropole.fr/fiches/opendata/gtfs_current.zip