### PR TITLE
Support Django 2.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -50,3 +50,6 @@ docs/_build
 feeds/
 !feeds/import/README.md
 !feeds/export/README.md
+
+# Pyenv
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ docs/_build
 feeds/
 !feeds/import/README.md
 !feeds/export/README.md
+
+# Pyenv
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
           python: "2.7"
         - env: TOX_ENV=py36-django111-postgis
           python: "3.6"
+        - env: TOX_ENV=py35-django20-postgis
+          python: "3.5"
+        - env: TOX_ENV=py36-django20-postgis
+          python: "3.6"
         - env: TOX_ENV=py35-django-master-postgis
           python: "3.5"
         - env: TOX_ENV=py36-django-master-postgis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: python
+dist: trusty
 sudo: false
+addons:
+  postgresql: "9.5"
+  apt:
+    packages:
+      - postgresql-9.5-postgis-2.3
 install: pip install tox coveralls
 script: tox -e $TOX_ENV
 after_success: coveralls

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ export your GTFS feeds in the original version, update multigtfs and your code,
 and re-import.
 
 multigtfs works with Django 1.8 (the long-term support, or LTS, release)
-through 1.11.  Support will follow the Django supported releases, as well as
-the Python versions supported by those releases.
+through 1.11 (the next LTS release), and 2.0 (in alpha).  Support will follow
+the Django supported releases, as well as the Python versions supported by
+those releases.
 
 All valid GTFS feeds are supported for import and export.  This includes
 feeds with extra columns not yet included in the GTFS spec, and feeds that

--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,8 @@ export your GTFS feeds in the original version, update multigtfs and your code,
 and re-import.
 
 multigtfs works with Django 1.8 (the long-term support, or LTS, release)
-through 1.11 (the next LTS release), and 2.0 (in alpha).  Support will follow
-the Django supported releases, as well as the Python versions supported by
-those releases.
+through 1.11 (the next LTS release), and 2.0.  Support will follow the Django
+supported releases, as well as the Python versions supported by those releases.
 
 All valid GTFS feeds are supported for import and export.  This includes
 feeds with extra columns not yet included in the GTFS spec, and feeds that

--- a/multigtfs/compat.py
+++ b/multigtfs/compat.py
@@ -101,3 +101,18 @@ def write_text_rows(writer, rows):
                 else:
                     new_row.append(item)
             writer.writerow(new_row)
+
+
+# The GeoQuerySet is deprecated in Django 1.8
+# https://docs.djangoproject.com/en/dev/releases/1.9/#django-contrib-gis
+# The GeoManager is deprecated in Django 1.9
+# https://docs.djangoproject.com/en/dev/releases/1.9/#geomanager-and-geoqueryset-custom-methods
+# They are removed in Django 2.0
+# https://docs.djangoproject.com/en/dev/releases/2.0/#features-removed-in-2-0
+if DJ_VERSION >= LooseVersion('2.0'):
+    from django.db.models import Manager, QuerySet
+else:
+    from django.contrib.gis.db.models import GeoManager as Manager
+    from django.contrib.gis.db.models.query import GeoQuerySet as QuerySet
+assert Manager
+assert QuerySet

--- a/multigtfs/models/base.py
+++ b/multigtfs/models/base.py
@@ -21,11 +21,11 @@ from logging import getLogger
 import re
 
 from django.contrib.gis.db import models
-from django.contrib.gis.db.models.query import GeoQuerySet
 from django.db.models.fields.related import ManyToManyField
 from django.utils.six import StringIO, text_type, PY3
 
-from multigtfs.compat import get_blank_value, write_text_rows
+from multigtfs.compat import (
+    get_blank_value, write_text_rows, Manager, QuerySet)
 
 logger = getLogger(__name__)
 re_point = re.compile(r'(?P<name>point)\[(?P<index>\d)\]')
@@ -34,7 +34,7 @@ large_queryset_size = 100000
 CSV_BOM = BOM_UTF8.decode('utf-8') if PY3 else BOM_UTF8
 
 
-class BaseQuerySet(GeoQuerySet):
+class BaseQuerySet(QuerySet):
     def populated_column_map(self):
         '''Return the _column_map without unused optional fields'''
         column_map = []
@@ -63,7 +63,7 @@ class BaseQuerySet(GeoQuerySet):
         return column_map
 
 
-class BaseManager(models.GeoManager):
+class BaseManager(Manager):
     def get_queryset(self):
         '''Return the custom queryset.'''
         return BaseQuerySet(self.model)

--- a/multigtfs/models/base.py
+++ b/multigtfs/models/base.py
@@ -141,22 +141,23 @@ class Base(models.Model):
         def instance_convert(field, feed, rel_name):
             def get_instance(value):
                 if value.strip():
-                    key1 = "{}:{}".format(field.rel.to.__name__, rel_name)
+                    related = field.related_model
+                    key1 = "{}:{}".format(related.__name__, rel_name)
                     key2 = text_type(value)
 
                     # Load existing objects
                     if key1 not in cache:
-                        pairs = field.rel.to.objects.filter(
-                            **{field.rel.to._rel_to_feed: feed}).values_list(
+                        pairs = related.objects.filter(
+                            **{related._rel_to_feed: feed}).values_list(
                             rel_name, 'id')
                         cache[key1] = dict((text_type(x), i) for x, i in pairs)
 
                     # Create new?
                     if key2 not in cache[key1]:
                         kwargs = {
-                            field.rel.to._rel_to_feed: feed,
+                            related._rel_to_feed: feed,
                             rel_name: value}
-                        cache[key1][key2] = field.rel.to.objects.create(
+                        cache[key1][key2] = related.objects.create(
                             **kwargs).id
                     return cache[key1][key2]
                 else:
@@ -199,7 +200,7 @@ class Base(models.Model):
                 converter = bool_convert
             elif isinstance(field, models.CharField):
                 converter = char_convert
-            elif field.rel:
+            elif field.is_relation:
                 converter = instance_convert(field, feed, rel_name)
                 assert not isinstance(field, models.ManyToManyField)
             elif field.null:
@@ -350,7 +351,7 @@ class Base(models.Model):
             if '__' in field_name:
                 local_field_name, subfield_name = field_name.split('__', 1)
                 field = cls._meta.get_field(local_field_name)
-                field_type = field.rel.to
+                field_type = field.related_model
                 model_name = field_type.__name__
                 if model_name in model_to_field_name:
                     # Already loaded this model under a different field name

--- a/multigtfs/models/route.py
+++ b/multigtfs/models/route.py
@@ -72,7 +72,7 @@ class Route(Base):
     def update_geometry(self):
         """Update the geometry from the Trips"""
         original = self.geometry
-        trips = self.trip_set.exclude(geometry=None)
+        trips = self.trip_set.exclude(geometry__isnull=True)
         unique_coords = set()
         unique_geom = list()
         for t in trips:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{27,34}-django18-{postgis,spatiallite}
     py{27,34,35}-django{19,110}-{postgis,spatiallite}
     py{27,34,35,36}-django111-{postgis,spatiallite}
-    py{35,36}-django-master-{postgis,spatiallite}
+    py{35,36}-django{20,-master}-{postgis,spatiallite}
 
 [flake8]
 exclude = .tox/*,.build/*,.dist/*,build/*
@@ -17,6 +17,7 @@ deps=
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0a1,<2.1
     django-master: https://github.com/django/django/archive/master.tar.gz
     postgis: psycopg2
     nose

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
 deps=
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    django110: Django==1.10,<1.11
+    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django-master: https://github.com/django/django/archive/master.tar.gz
     postgis: psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0a1,<2.1
+    django20: Django>=2.0,<2.1
     django-master: https://github.com/django/django/archive/master.tar.gz
     postgis: psycopg2
     nose


### PR DESCRIPTION
Django 2.0a1, the first alpha release, is now available.

* Use the standard ``Manager``/``Queryset`` in Django 2.0. Continue using ``GeoManager`` and ``GeoQueryset`` in previous versions. **Note**: We may be able to use the standard versions as far back as 1.8., if we're willing to take a version bump.
* Use the new field API for relationship fields