### PR TITLE
Do exact match when searching for file to import

### DIFF
--- a/multigtfs/models/feed.py
+++ b/multigtfs/models/feed.py
@@ -97,7 +97,7 @@ class Feed(models.Model):
         try:
             for klass in gtfs_order:
                 for f in filelist:
-                    if f == klass._filename:
+                    if os.path.basename(f) == klass._filename:
                         start_time = time.time()
                         table = opener(f)
                         count = klass.import_txt(table, self) or 0

--- a/multigtfs/models/feed.py
+++ b/multigtfs/models/feed.py
@@ -97,7 +97,7 @@ class Feed(models.Model):
         try:
             for klass in gtfs_order:
                 for f in filelist:
-                    if f.endswith(klass._filename):
+                    if f == klass._filename:
                         start_time = time.time()
                         table = opener(f)
                         count = klass.import_txt(table, self) or 0


### PR DESCRIPTION
When searching the feed to import, endswith() is used to search for the file in the zip up to now. It causes problem when there are custom files like routes_stops.txt, confusing stops.txt with the former file with this approach. I suggest to replace the endswith() comparison with an exact match.